### PR TITLE
Remove Swift 4 requirement

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,6 @@ To be added to the list, software should meet the following criteria:
 - Well documented
 - Work with the latest SDK
 - Have at least 15 stars on (GitHub project)
-- Support `Swift 4`
 
 If an item on the list no longer meets the above criteria, open an issue to have it be removed.
 


### PR DESCRIPTION
Remove Swift 4 requirement from contribution guides. 😄 